### PR TITLE
refactor: engines.node now 20.x instead of >=20.6.0, vercel compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
 		"tailwind-merge": "^2.2.2"
 	},
 	"engines": {
-		"node": ">=20.6.0"
+		"node": "20.x"
 	}
 }


### PR DESCRIPTION
- make node version compatible with vercel build